### PR TITLE
Histogram tail fix. Wrong parameter passed to GetRange()

### DIFF
--- a/whitesource-nant/Whitesource.Agent/Report/ReportGenerator.cs
+++ b/whitesource-nant/Whitesource.Agent/Report/ReportGenerator.cs
@@ -248,7 +248,7 @@ namespace Whitesource.Agent.Report
                 int tailSum = 0;
                 if (tailSize > 0)
                 {
-                    foreach (KeyValuePair<String, int> pair in licenses.GetRange(LICENSE_LIMIT, licenseCount))
+                    foreach (KeyValuePair<String, int> pair in licenses.GetRange(LICENSE_LIMIT, tailSize))
                     {
                         tailSum += pair.Value;
                     }


### PR DESCRIPTION
Exception:
System.ArgumentException: Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.List`1.GetRange(Int32 index, Int32 count)
   at Whitesource.Agent.Report.ReportGenerator.CreateLicenseHistogram(CheckPoliciesResult result) in C:\softwaredistribution\nant-task\whitesource-nant\Whitesource.Agent\Report\ReportGenerator.cs:line 251